### PR TITLE
Fixes issue with content not loading

### DIFF
--- a/src/editor/editor.directive.ts
+++ b/src/editor/editor.directive.ts
@@ -79,7 +79,7 @@ export class FroalaEditorDirective implements ControlValueAccessor {
   // Update editor with model contents.
   private updateEditor(content: any) {
 
-    if (JSON.stringify(this._oldModel) == JSON.stringify(content)) {
+    if (JSON.stringify(this._oldModel) == JSON.stringify(content) || !content) {
       return;
     }
     this._model = content;


### PR DESCRIPTION
When content being passed through froalaModel is initialised with no content but is then loaded one second after (once it's received from a subscription), the content sometimes does not show the content.