### PR TITLE
Update package.json to include the repository

### DIFF
--- a/projects/library/package.json
+++ b/projects/library/package.json
@@ -1,5 +1,10 @@
 {
   "name": "angular-froala-wysiwyg",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/froala/angular-froala-wysiwyg.git",
+    "directory":"projects/library"
+  },
   "version": "4.0.6",
   "dependencies": {
     "froala-editor": "4.0.6"


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* angular-froala-wysiwyg